### PR TITLE
fix breaking changes

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,6 +55,7 @@
     "import ast\n",
     "\n",
     "import dash\n",
+    "from dash import html, dcc\n",
     "import jupyter_dash\n",
     "\n",
     "import dash_bootstrap_components as dbc"
@@ -62,14 +63,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [],
    "source": [
     "#export\n",
-    "import dash_core_components as dcc\n",
-    "import dash_html_components as html\n",
-    "\n",
     "from dash.dependencies import Input, Output, State\n",
     "from dash.exceptions import PreventUpdate"
    ]
@@ -97,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [
     {
@@ -489,7 +487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [
     {
@@ -533,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [
     {
@@ -567,7 +565,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -588,7 +586,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -604,7 +602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -625,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -642,7 +640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -661,7 +659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,7 +668,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [
     {
@@ -704,7 +702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [
     {
@@ -751,7 +749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -781,7 +779,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [
     {
@@ -828,7 +826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -848,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [
     {
@@ -866,7 +864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [
     {
@@ -894,7 +892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -912,7 +910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -921,7 +919,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -942,7 +940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [
     {
@@ -972,7 +970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1025,7 +1023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1102,7 +1100,7 @@
     "                        a hidden html.Div instead. Defaults to False.\n",
     "        \"\"\" \n",
     "        if hide:\n",
-    "            if isinstance(element, dbc.Col) or isinstance(element, dbc.FormGroup):\n",
+    "            if isinstance(element, dbc.Col) or isinstance(element, dbc.Row):\n",
     "                return html.Div(element.children, style=dict(display=\"none\"))\n",
     "            else:\n",
     "                return html.Div(element, style=dict(display=\"none\"))\n",
@@ -1304,7 +1302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [
     {
@@ -1455,7 +1453,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"DashComponent.component_callbacks\" class=\"doc_header\"><code>DashComponent.component_callbacks</code><a href=\"__main__.py#L263\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"DashComponent.component_callbacks\" class=\"doc_header\"><code>DashComponent.component_callbacks</code><a href=\"__main__.py#L257\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>DashComponent.component_callbacks</code>(**`app`**)\n",
        "\n",
@@ -1471,7 +1469,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"DashComponent.register_callbacks\" class=\"doc_header\"><code>DashComponent.register_callbacks</code><a href=\"__main__.py#L270\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"DashComponent.register_callbacks\" class=\"doc_header\"><code>DashComponent.register_callbacks</code><a href=\"__main__.py#L264\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>DashComponent.register_callbacks</code>(**`app`**)\n",
        "\n",
@@ -1530,7 +1528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1573,7 +1571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1600,7 +1598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1636,7 +1634,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1655,7 +1653,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [
     {
@@ -1669,7 +1667,7 @@
        " ('input3-0', 'max')]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1681,7 +1679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1705,7 +1703,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1738,7 +1736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1747,7 +1745,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [
     {
@@ -1756,7 +1754,7 @@
        "[('input-first-n-1', 'value')]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1767,7 +1765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1778,7 +1776,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [
     {
@@ -1800,7 +1798,7 @@
       "          - a\n",
       "          - dumb\n",
       "          - example\n",
-      "          filepath: file_factory.pkl\n",
+      "          filepath: list_factory.pkl\n",
       "    first_n: 2\n",
       "    name: '1'\n",
       "\n"
@@ -1820,7 +1818,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1829,7 +1827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1839,17 +1837,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 119,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Couldn't find file_factory.pkl! So loading from config instead...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "list_component.dump()\n",
     "list_component2 = ListComponent.from_yaml(\"list_component.yaml\", try_pickles=True)\n",
@@ -1858,7 +1848,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1867,16 +1857,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'file_factory.pkl'"
+       "'list_factory.pkl'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 121,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1895,7 +1885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 122,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1942,7 +1932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1973,7 +1963,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1982,7 +1972,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 125,
    "metadata": {},
    "outputs": [
     {
@@ -1991,7 +1981,7 @@
        "[('input-first-n-1', 'value'), ('input-first-n-2', 'value')]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 125,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2002,16 +1992,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 126,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Div([Button(children='Reset', id='reset-button-main'), Tabs(children=[Tab(children=Div([Input(id='input-first-n-1', value=2, type='number', max=5, min=0), Div(children='this is', id='output-div-1')]), id='tabs-1', label='Dash', value='1'), Tab(children=Div([Input(id='input-first-n-2', value=3, type='number', max=5, min=0), Div(children='this is a', id='output-div-2')]), id='tabs-2', label='Dash', value='2')], id='tabs', value='1')])"
+       "Div([Button(children='Reset', id='reset-button-main'), Tabs(children=[Tab(children=Div([Input(value=2, type='number', min=0, max=5, id='input-first-n-1'), Div(children='this is', id='output-div-1')]), id='tabs-1', label='Dash', value='1'), Tab(children=Div([Input(value=3, type='number', min=0, max=5, id='input-first-n-2'), Div(children='this is a', id='output-div-2')]), id='tabs-2', label='Dash', value='2')], id='tabs', value='1')])"
       ]
      },
-     "execution_count": null,
+     "execution_count": 126,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2022,7 +2012,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [
     {
@@ -2032,7 +2022,7 @@
        "  '2': [('input-first-n-2', 'value')]}}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 127,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2043,7 +2033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [
     {
@@ -2064,7 +2054,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 129,
    "metadata": {},
    "outputs": [
     {
@@ -2073,7 +2063,7 @@
        "[('tabs', 'value'), ('input-first-n-1', 'value'), ('input-first-n-2', 'value')]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 129,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2088,7 +2078,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 130,
    "metadata": {},
    "outputs": [
     {
@@ -2097,7 +2087,7 @@
        "[]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 130,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2111,7 +2101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 131,
    "metadata": {},
    "outputs": [
     {
@@ -2156,7 +2146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2174,7 +2164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 133,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2202,7 +2192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2239,7 +2229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 135,
    "metadata": {},
    "outputs": [
     {
@@ -2264,7 +2254,7 @@
       "          filepath: file_factory.pkl\n",
       "    first_n1: 2\n",
       "    first_n2: 3\n",
-      "    name: GmrYyUT7T8\n",
+      "    name: 7wFsEqmpVq\n",
       "\n"
      ]
     }
@@ -2276,7 +2266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2307,7 +2297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 137,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2363,7 +2353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 138,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2420,7 +2410,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 139,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2447,7 +2437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 140,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2491,7 +2481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 141,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2629,7 +2619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 142,
    "metadata": {},
    "outputs": [
     {
@@ -2713,10 +2703,12 @@
        "    :type assets_ignore: string\n",
        "\n",
        "    :param assets_external_path: an absolute URL from which to load assets.\n",
-       "        Use with ``serve_locally=False``. Dash can still find js and css to\n",
-       "        automatically load if you also keep local copies in your assets\n",
-       "        folder that Dash can index, but external serving can improve\n",
-       "        performance and reduce load on the Dash server.\n",
+       "        Use with ``serve_locally=False``. assets_external_path is joined\n",
+       "        with assets_url_path to determine the absolute url to the\n",
+       "        asset folder. Dash can still find js and css to automatically load\n",
+       "        if you also keep local copies in your assets folder that Dash can index,\n",
+       "        but external serving can improve performance and reduce load on\n",
+       "        the Dash server.\n",
        "        env: ``DASH_ASSETS_EXTERNAL_PATH``\n",
        "    :type assets_external_path: string\n",
        "\n",
@@ -2748,7 +2740,7 @@
        "    :type serve_locally: boolean\n",
        "\n",
        "    :param compress: Use gzip to compress files and data served by Flask.\n",
-       "        Default ``True``\n",
+       "        Default ``False``\n",
        "    :type compress: boolean\n",
        "\n",
        "    :param meta_tags: html <meta> tags to be added to the index page.\n",
@@ -2793,6 +2785,11 @@
        "        and redo buttons for stepping through the history of the app state.\n",
        "    :type show_undo_redo: boolean\n",
        "\n",
+       "    :param extra_hot_reload_paths: A list of paths to watch for changes, in\n",
+       "        addition to assets and known Python and JS code, if hot reloading is\n",
+       "        enabled.\n",
+       "    :type extra_hot_reload_paths: list of strings\n",
+       "\n",
        "    :param plugins: Extend Dash functionality by passing a list of objects\n",
        "        with a ``plug`` method, taking a single argument: this app, which will\n",
        "        be called after the Flask server is attached.\n",
@@ -2806,6 +2803,10 @@
        "    Set to None or '' if you don't want the document.title to change or if you\n",
        "    want to control the document.title through a separate component or\n",
        "    clientside callback.\n",
+       "\n",
+       "    :param long_callback_manager: Long callback manager instance to support the\n",
+       "    ``@app.long_callback`` decorator. Currently an instance of one of\n",
+       "    ``DiskcacheLongCallbackManager`` or ``CeleryLongCallbackManager``\n",
        "    "
       ],
       "text/plain": [
@@ -2871,17 +2872,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 143,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Warning: the use of _register_callbacks() will be deprecated! Use component_callbacks() from now on.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "db = DashApp(list_composite, mode='external', port=9000, querystrings=True, bootstrap=dbc.themes.FLATLY)"
    ]
@@ -2900,7 +2893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 144,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2910,7 +2903,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 145,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2927,7 +2920,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 146,
    "metadata": {},
    "outputs": [
     {
@@ -2957,14 +2950,14 @@
       "                filepath: file_factory.pkl\n",
       "          first_n1: 2\n",
       "          first_n2: 3\n",
-      "          name: GmrYyUT7T8\n",
+      "          name: 7wFsEqmpVq\n",
       "    port: 9000\n",
       "    mode: external\n",
       "    querystrings: true\n",
-      "    bootstrap: https://stackpath.bootstrapcdn.com/bootswatch/4.5.0/flatly/bootstrap.min.css\n",
+      "    bootstrap: https://cdn.jsdelivr.net/npm/bootswatch@5.1.3/dist/flatly/bootstrap.min.css\n",
       "    kwargs:\n",
       "      external_stylesheets:\n",
-      "      - https://stackpath.bootstrapcdn.com/bootswatch/4.5.0/flatly/bootstrap.min.css\n",
+      "      - https://cdn.jsdelivr.net/npm/bootswatch@5.1.3/dist/flatly/bootstrap.min.css\n",
       "      suppress_callback_exceptions: true\n",
       "\n"
      ]
@@ -2976,7 +2969,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 147,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2985,24 +2978,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 148,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Warning: the use of _register_callbacks() will be deprecated! Use component_callbacks() from now on.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "db2 = DashApp.from_yaml(\"dashboard.yaml\", force_pickles=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 149,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3012,7 +2997,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 150,
    "metadata": {},
    "outputs": [
     {
@@ -3053,6 +3038,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,

--- a/dash_oop_components/core.py
+++ b/dash_oop_components/core.py
@@ -18,14 +18,12 @@ from urllib.parse import urlparse, parse_qs, urlencode
 import ast
 
 import dash
+from dash import html, dcc
 import jupyter_dash
 
 import dash_bootstrap_components as dbc
 
 # Cell
-import dash_core_components as dcc
-import dash_html_components as html
-
 from dash.dependencies import Input, Output, State
 from dash.exceptions import PreventUpdate
 
@@ -395,7 +393,7 @@ class DashComponent(DashComponentBase):
                         a hidden html.Div instead. Defaults to False.
         """
         if hide:
-            if isinstance(element, dbc.Col) or isinstance(element, dbc.FormGroup):
+            if isinstance(element, dbc.Col) or isinstance(element, dbc.Row):
                 return html.Div(element.children, style=dict(display="none"))
             else:
                 return html.Div(element, style=dict(display="none"))


### PR DESCRIPTION
I've migrated dash_oop_components to dash-bootstrap-components v1 API. 

These changes include:
-  It is no longer necessary to use FormGroup to align components in a form. I modified `make_hideable` function to accept Col and Row components
- The way to import `dash_core_components` and `dash_html_components` has changed to `from dash import dcc, html`